### PR TITLE
[#159990511] integrate application insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "homepage": "https://github.com/teamdigitale/italia-backend#readme",
   "dependencies": {
+    "applicationinsights": "^1.0.3",
     "awilix": "^3.0.9",
     "azure-sb": "^0.10.6",
     "body-parser": "^1.18.3",
@@ -62,7 +63,7 @@
     "request-ip": "^2.1.1",
     "spid-passport": "git://github.com/gunzip/spid-passport.git#5900adf9",
     "typescript": "^2.9.2",
-    "ulid": "^2.2.2",
+    "ulid": "^2.3.0",
     "validator": "^10.4.0",
     "winston": "^3.0.0",
     "xmldom": "^0.1.27"

--- a/src/utils/applicationinsights.ts
+++ b/src/utils/applicationinsights.ts
@@ -121,6 +121,8 @@ export class ApplicationInsightsWinstonTransport extends WinstonTransport {
     setImmediate(() => this.emit("logged", info));
 
     switch (info.level) {
+      case IWinstonTransportLevel.verbose:
+      case IWinstonTransportLevel.silly:
       case IWinstonTransportLevel.debug:
         if (this.level === IWinstonTransportLevel.debug) {
           this.applicationInsightsClient.trackTrace({

--- a/src/utils/applicationinsights.ts
+++ b/src/utils/applicationinsights.ts
@@ -1,0 +1,152 @@
+/**
+ * Application insights client configuration.
+ *
+ * To use this aside winston:
+ *
+ * Set APPINSIGHTS_INSTRUMENTATIONKEY environment variable
+ * then add a new winston transport:
+ *
+ * import { log } from "logger";
+ * import {TelemetryClient } from "applicationinsights";
+ * import {
+ *   ApplicationInsightsWinstonTransport,
+ *   wrapCustomTelemetryClient
+ * } from "./applicationinsights";
+ *
+ * const telemetryClient = wrapCustomTelemetryClient(
+ *   isProduction,
+ *   TelemetryClient()
+ * )();
+ *
+ * log.add(new ApplicationInsightsWinstonTransport(telemetryClient);
+ *
+ */
+import * as ApplicationInsights from "applicationinsights";
+import {
+  Data,
+  EventData
+} from "applicationinsights/out/Declarations/Contracts";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { ulid } from "ulid";
+import * as WinstonTransport from "winston-transport";
+import { IWinstonTransportInfo, IWinstonTransportLevel } from "./logger";
+
+export interface ITelemetryParams {
+  readonly operationId?: NonEmptyString;
+  readonly operationParentId?: NonEmptyString;
+}
+
+/**
+ * A TelemetryClient instance cannot be shared between track calls
+ * as custom properties and tags (ie. operationId) are part
+ * of a mutable shared state attached to the instance.
+ *
+ * This method returns a TelemetryClient with a custom
+ * TelemetryProcessor that stores tags and properties
+ * before any call to track(); in this way the returned
+ * instance of the TelemetryClient can be shared safely.
+ */
+export function wrapCustomTelemetryClient(
+  isTracingDisabled: boolean,
+  client: ApplicationInsights.TelemetryClient
+): (
+  params?: ITelemetryParams,
+  commonProperties?: Record<string, string>
+) => ApplicationInsights.TelemetryClient {
+  if (isTracingDisabled) {
+    // this won't disable manual calls to trackEvent / trackDependency
+    ApplicationInsights.Configuration.setAutoCollectConsole(false)
+      .setAutoCollectDependencies(false)
+      .setAutoCollectPerformance(false)
+      .setAutoCollectRequests(false)
+      .setInternalLogging(false)
+      // see https://stackoverflow.com/questions/49438235/application-insights-metric-in-aws-lambda/49441135#49441135
+      .setUseDiskRetryCaching(false);
+  }
+  return (params, commonProperties) => {
+    client.addTelemetryProcessor(env => {
+      // tslint:disable-next-line:no-object-mutation
+      env.tags = {
+        ...env.tags,
+        [client.context.keys.operationId]:
+          params && params.operationId ? params.operationId : ulid(),
+        [client.context.keys.operationParentId]: params
+          ? params.operationParentId
+          : undefined
+      };
+      // cast needed due to https://github.com/Microsoft/ApplicationInsights-node.js/issues/392
+      const data = env.data as Data<EventData>;
+      // tslint:disable-next-line:no-object-mutation
+      data.baseData.properties = {
+        ...data.baseData.properties,
+        ...commonProperties
+      };
+      // return true to execute the following telemetry processor
+      return true;
+    });
+    return client;
+  };
+}
+
+export type CustomTelemetryClientFactory = ReturnType<
+  typeof wrapCustomTelemetryClient
+>;
+
+////////////////
+
+/**
+ * A custom Winston Transport that logs to ApplicationInsights
+ */
+export class ApplicationInsightsWinstonTransport extends WinstonTransport {
+  public readonly name: string;
+  private readonly applicationInsightsClient: ApplicationInsights.TelemetryClient;
+  constructor(
+    applicationInsightsClient: ApplicationInsights.TelemetryClient,
+    options: WinstonTransport.TransportStreamOptions = {}
+  ) {
+    super(options);
+    this.name = "ApplicationInsightsWinstonTransport";
+    this.level = options.level || "info";
+    this.applicationInsightsClient = applicationInsightsClient;
+  }
+
+  public log(
+    info: IWinstonTransportInfo,
+    callback: (err: Error | undefined, cont: boolean) => void = () => void 0
+  ): void {
+    if (this.silent) {
+      return callback(undefined, true);
+    }
+
+    setImmediate(() => this.emit("logged", info));
+
+    switch (info.level) {
+      case IWinstonTransportLevel.debug:
+        if (this.level === IWinstonTransportLevel.debug) {
+          this.applicationInsightsClient.trackTrace({
+            message: info.message,
+            properties: {
+              type: info.level
+            }
+          });
+        }
+        break;
+      case IWinstonTransportLevel.warn:
+      case IWinstonTransportLevel.info:
+        this.applicationInsightsClient.trackTrace({
+          message: info.message,
+          properties: {
+            type: info.level
+          }
+        });
+        break;
+      case IWinstonTransportLevel.error:
+        this.applicationInsightsClient.trackException({
+          exception: new Error(info.message)
+        });
+        break;
+    }
+
+    callback(undefined, true);
+  }
+}

--- a/src/utils/applicationinsights.ts
+++ b/src/utils/applicationinsights.ts
@@ -18,7 +18,7 @@
  *   TelemetryClient()
  * )();
  *
- * log.add(new ApplicationInsightsWinstonTransport(telemetryClient);
+ * log.add(new ApplicationInsightsWinstonTransport(telemetryClient));
  *
  */
 import * as ApplicationInsights from "applicationinsights";

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,23 @@
+/**
+ * Common logging utilities (winston configuration).
+ */
 import * as logform from "logform";
 import { createLogger, format, transports } from "winston";
-
 const { timestamp, printf } = logform.format;
+import { DateFromISOStringType } from "io-ts-types/lib/Date/DateFromISOString";
+
+export const enum IWinstonTransportLevel {
+  "info" = "info",
+  "error" = "error",
+  "warn" = "warn",
+  "debug" = "debug"
+}
+
+export interface IWinstonTransportInfo {
+  readonly message: string;
+  readonly level: IWinstonTransportLevel;
+  readonly timestamp: DateFromISOStringType;
+}
 
 export const log = createLogger({
   format: format.combine(

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,7 +10,9 @@ export const enum IWinstonTransportLevel {
   "info" = "info",
   "error" = "error",
   "warn" = "warn",
-  "debug" = "debug"
+  "debug" = "debug",
+  "verbose" = "verbose",
+  "silly" = "silly"
 }
 
 export interface IWinstonTransportInfo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,6 +345,14 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
+applicationinsights@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.3.tgz#ddbf503612cbbfd7c28e087894dd28cfb06450a1"
+  dependencies:
+    diagnostic-channel "0.2.0"
+    diagnostic-channel-publishers "0.2.1"
+    zone.js "0.7.6"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -1414,6 +1422,16 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
 
+diagnostic-channel-publishers@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz#8e2d607a8b6d79fe880b548bc58cc6beb288c4f3"
+
+diagnostic-channel@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz#cc99af9612c23fb1fff13612c72f2cbfaa8d5a17"
+  dependencies:
+    semver "^5.3.0"
+
 diagnostics@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/diagnostics/-/diagnostics-1.1.1.tgz#cab6ac33df70c9d9a727490ae43ac995a769b22a"
@@ -1723,17 +1741,6 @@ expect-ct@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/expect-ct/-/expect-ct-0.1.1.tgz#de84476a2dbcb85000d5903737e9bc8a5ba7b897"
 
-expect@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-23.4.0.tgz#6da4ecc99c1471253e7288338983ad1ebadb60c3"
-  dependencies:
-    ansi-styles "^3.2.0"
-    jest-diff "^23.2.0"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^23.2.0"
-    jest-message-util "^23.4.0"
-    jest-regex-util "^23.3.0"
-
 expect@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-23.5.0.tgz#18999a0eef8f8acf99023fde766d9c323c2562ed"
@@ -1874,7 +1881,6 @@ fetch-cookie@~0.6.0:
 
 fetch-ponyfill@amarzavery/fetch-ponyfill#master:
   version "4.1.0"
-  uid "136e6f8192bdb2aa0b7983f0b3b4361c357be9db"
   resolved "https://codeload.github.com/amarzavery/fetch-ponyfill/tar.gz/136e6f8192bdb2aa0b7983f0b3b4361c357be9db"
   dependencies:
     fetch-cookie "~0.6.0"
@@ -2873,24 +2879,6 @@ jest-cli@^23.5.0:
     which "^1.2.12"
     yargs "^11.0.0"
 
-jest-config@^23.4.2:
-  version "23.4.2"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.4.2.tgz#62a105e14b8266458f2bf4d32403b2c44418fa77"
-  dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^23.4.2"
-    chalk "^2.0.1"
-    glob "^7.1.1"
-    jest-environment-jsdom "^23.4.0"
-    jest-environment-node "^23.4.0"
-    jest-get-type "^22.1.0"
-    jest-jasmine2 "^23.4.2"
-    jest-regex-util "^23.3.0"
-    jest-resolve "^23.4.1"
-    jest-util "^23.4.0"
-    jest-validate "^23.4.0"
-    pretty-format "^23.2.0"
-
 jest-config@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.5.0.tgz#3770fba03f7507ee15f3b8867c742e48f31a9773"
@@ -2910,15 +2898,6 @@ jest-config@^23.5.0:
     micromatch "^2.3.11"
     pretty-format "^23.5.0"
 
-jest-diff@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.2.0.tgz#9f2cf4b51e12c791550200abc16b47130af1062a"
-  dependencies:
-    chalk "^2.0.1"
-    diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.2.0"
-
 jest-diff@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.5.0.tgz#250651a433dd0050290a07642946cc9baaf06fba"
@@ -2937,13 +2916,6 @@ jest-docblock@^23.2.0:
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
   dependencies:
     detect-newline "^2.1.0"
-
-jest-each@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.4.0.tgz#2fa9edd89daa1a4edc9ff9bf6062a36b71345143"
-  dependencies:
-    chalk "^2.0.1"
-    pretty-format "^23.2.0"
 
 jest-each@^23.5.0:
   version "23.5.0"
@@ -2984,23 +2956,6 @@ jest-haste-map@^23.5.0:
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^23.4.2:
-  version "23.4.2"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz#2fbf52f93e43ed4c5e7326a90bb1d785be4321ac"
-  dependencies:
-    babel-traverse "^6.0.0"
-    chalk "^2.0.1"
-    co "^4.6.0"
-    expect "^23.4.0"
-    is-generator-fn "^1.0.0"
-    jest-diff "^23.2.0"
-    jest-each "^23.4.0"
-    jest-matcher-utils "^23.2.0"
-    jest-message-util "^23.4.0"
-    jest-snapshot "^23.4.2"
-    jest-util "^23.4.0"
-    pretty-format "^23.2.0"
-
 jest-jasmine2@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz#05fe7f1788e650eeb5a03929e6461ea2e9f3db53"
@@ -3023,14 +2978,6 @@ jest-leak-detector@^23.5.0:
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.5.0.tgz#14ac2a785bd625160a2ea968fd5d98b7dcea3e64"
   dependencies:
     pretty-format "^23.5.0"
-
-jest-matcher-utils@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz#4d4981f23213e939e3cedf23dc34c747b5ae1913"
-  dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.2.0"
 
 jest-matcher-utils@^23.5.0:
   version "23.5.0"
@@ -3064,14 +3011,6 @@ jest-resolve-dependencies@^23.5.0:
   dependencies:
     jest-regex-util "^23.3.0"
     jest-snapshot "^23.5.0"
-
-jest-resolve@^23.4.1:
-  version "23.4.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.4.1.tgz#7f3c17104732a2c0c940a01256025ed745814982"
-  dependencies:
-    browser-resolve "^1.11.3"
-    chalk "^2.0.1"
-    realpath-native "^1.0.0"
 
 jest-resolve@^23.5.0:
   version "23.5.0"
@@ -3129,21 +3068,6 @@ jest-serializer@^23.0.1:
   version "23.0.1"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
 
-jest-snapshot@^23.4.2:
-  version "23.4.2"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.4.2.tgz#8fa6130feb5a527dac73e5fa80d86f29f7c42ab6"
-  dependencies:
-    babel-types "^6.0.0"
-    chalk "^2.0.1"
-    jest-diff "^23.2.0"
-    jest-matcher-utils "^23.2.0"
-    jest-message-util "^23.4.0"
-    jest-resolve "^23.4.1"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    pretty-format "^23.2.0"
-    semver "^5.5.0"
-
 jest-snapshot@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.5.0.tgz#cc368ebd8513e1175e2a7277f37a801b7358ae79"
@@ -3171,15 +3095,6 @@ jest-util@^23.4.0:
     mkdirp "^0.5.1"
     slash "^1.0.0"
     source-map "^0.6.0"
-
-jest-validate@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.4.0.tgz#d96eede01ef03ac909c009e9c8e455197d48c201"
-  dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    leven "^2.1.0"
-    pretty-format "^23.2.0"
 
 jest-validate@^23.5.0:
   version "23.5.0"
@@ -4514,13 +4429,6 @@ prettier@^1.12.1, prettier@^1.14.2:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
-pretty-format@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"
-  dependencies:
-    ansi-regex "^3.0.0"
-    ansi-styles "^3.2.0"
-
 pretty-format@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.5.0.tgz#0f9601ad9da70fe690a269cd3efca732c210687c"
@@ -5648,7 +5556,7 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-ulid@^2.2.2:
+ulid@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/ulid/-/ulid-2.3.0.tgz#93063522771a9774121a84d126ecd3eb9804071f"
 
@@ -6123,3 +6031,7 @@ z-schema@^3.19.1:
     validator "^10.0.0"
   optionalDependencies:
     commander "^2.7.1"
+
+zone.js@0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.6.tgz#fbbc39d3e0261d0986f1ba06306eb3aeb0d22009"


### PR DESCRIPTION
This PR does nothing by itself. It adds an ApplicationInsights winston transport that must be set up
before calling any log* method (see [here](https://github.com/teamdigitale/italia-backend/pull/293/files#diff-d746dc18af77137dbd3942db2b6e368aR9)).

To make this work one must set a new environment variable `APPINSIGHTS_INSTRUMENTATIONKEY` (into the kubernetes configuration for the deployment and/or using kubectl). Ask the Azure administrator for the value of this variable.