### PR TITLE
[#161981230] bind error code to page url

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -73,7 +73,7 @@ function withSpidAuth(
           clientErrorRedirectionUrl +
             fromNullable(err.statusXml)
               .chain(statusXml => getErrorCodeFromResponse(statusXml))
-              .chain(errorCode => some(`?errorCode=${errorCode}`))
+              .map(errorCode =>`?errorCode=${errorCode}`)
               .getOrElse("")
         );
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ import * as t from "io-ts";
 import * as morgan from "morgan";
 import * as passport from "passport";
 
-import { fromNullable, some } from "fp-ts/lib/Option";
+import { fromNullable } from "fp-ts/lib/Option";
 
 import MessagesController from "./controllers/messagesController";
 import NotificationController from "./controllers/notificationController";
@@ -73,7 +73,7 @@ function withSpidAuth(
           clientErrorRedirectionUrl +
             fromNullable(err.statusXml)
               .chain(statusXml => getErrorCodeFromResponse(statusXml))
-              .map(errorCode =>`?errorCode=${errorCode}`)
+              .map(errorCode => `?errorCode=${errorCode}`)
               .getOrElse("")
         );
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,7 @@ import NotificationController from "./controllers/notificationController";
 import ServicesController from "./controllers/servicesController";
 
 import { DOMParser } from "xmldom";
+
 import { Express } from "express";
 import expressEnforcesSsl = require("express-enforces-ssl");
 import {
@@ -67,20 +68,23 @@ function withSpidAuth(
       if (err) {
         log.error("Error in SPID authentication: %s", err);
         const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(err.statusXml || "","text/xml");
-        let errorCode = "";
+        const xmlDoc = parser.parseFromString(err.statusXml || "", "text/xml");
         if (!!xmlDoc) {
           const errorElement = xmlDoc.getElementsByTagName("StatusMessage");
           if (errorElement.length > 0) {
             const indexString = "ErrorCode nr";
             const errorString = errorElement[0].textContent || "";
-            errorCode = errorString.slice(
+            const errorCode = errorString.slice(
               errorString.indexOf(indexString) + indexString.length
+            );
+
+            return res.redirect(
+              clientErrorRedirectionUrl +
+                (errorCode.length ? `?errorCode=${errorCode}` : "")
             );
           }
         }
-        res.redirect(clientErrorRedirectionUrl + (errorCode.length ? `?errorCode=${errorCode}` : ''));
-        return;
+        return res.redirect(clientErrorRedirectionUrl);
       }
       if (!user) {
         log.error("Error in SPID authentication: no user found");

--- a/src/controllers/authenticationController.ts
+++ b/src/controllers/authenticationController.ts
@@ -82,7 +82,6 @@ export default class AuthenticationController {
 
     return ResponsePermanentRedirect(urlWithToken);
   }
-
   /**
    * Retrieves the logout url from the IDP.
    */

--- a/src/utils/getErrorCodeFromResponse.ts
+++ b/src/utils/getErrorCodeFromResponse.ts
@@ -1,6 +1,8 @@
 import { DOMParser } from "xmldom";
 
-import { fromNullable, none, Option, some, tryCatch } from "fp-ts/lib/Option";
+import { none, Option, some, tryCatch } from "fp-ts/lib/Option";
+
+type SpidError = string;
 
 /**
  * Extract StatusMessage from SAML response
@@ -8,9 +10,10 @@ import { fromNullable, none, Option, some, tryCatch } from "fp-ts/lib/Option";
  * ie. for <StatusMessage>ErrorCode nr22</StatusMessage>
  * returns "22"
  */
-export default function getErrorCodeFromResponse(xml: string): Option<string> {
-  return fromNullable(xml)
-    .chain(xmlStr => tryCatch(() => new DOMParser().parseFromString(xmlStr)))
+export default function getErrorCodeFromResponse(
+  xml: string
+): Option<SpidError> {
+  return tryCatch(() => new DOMParser().parseFromString(xml))
     .chain(
       xmlResponse =>
         xmlResponse

--- a/src/utils/getErrorCodeFromResponse.ts
+++ b/src/utils/getErrorCodeFromResponse.ts
@@ -1,0 +1,34 @@
+import { DOMParser } from "xmldom";
+
+import { fromNullable, none, Option, some, tryCatch } from "fp-ts/lib/Option";
+
+/**
+ * Extract StatusMessage from SAML response
+ *
+ * ie. for <StatusMessage>ErrorCode nr22</StatusMessage>
+ * returns "22"
+ */
+export default function getErrorCodeFromResponse(xml: string): Option<string> {
+  return fromNullable(xml)
+    .chain(xmlStr => tryCatch(() => new DOMParser().parseFromString(xmlStr)))
+    .chain(
+      xmlResponse =>
+        xmlResponse
+          ? some(xmlResponse.getElementsByTagName("StatusMessage"))
+          : none
+    )
+    .chain(responseStatusMessageEl => {
+      return responseStatusMessageEl &&
+        responseStatusMessageEl[0] &&
+        responseStatusMessageEl[0].textContent
+        ? some(responseStatusMessageEl[0].textContent!.trim())
+        : none;
+    })
+    .chain(errorString => {
+      const indexString = "ErrorCode nr";
+      const errorCode = errorString.slice(
+        errorString.indexOf(indexString) + indexString.length
+      );
+      return errorCode ? some(errorCode) : none;
+    });
+}


### PR DESCRIPTION
This PR aims to attach error numbers found in the SAML XML assertion, received by SP's "assertionConsumerService", to the error page URL "`/error.html`" coming from the IdP sever.

That way the resulting URL sent to the app client should be "`/error.html?errorCode=XX`".