### PR TITLE
[#165307029] On new login, invalidate existing sessions

### DIFF
--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -582,7 +582,7 @@ describe("RedisSessionStorage#del", () => {
       walletDelSuccess: number,
       expected: Error
     ) => {
-      mockDel.mockImplementationOnce((_, __, callback) => {
+      mockDel.mockImplementationOnce((_, callback) => {
         callback(sessionDelErr, sessionDelSuccess);
       });
 
@@ -590,31 +590,19 @@ describe("RedisSessionStorage#del", () => {
         callback(walletDelErr, walletDelSuccess);
       });
 
-      mockSrem.mockImplementation((_, __, callback) => {
-        callback(undefined, 1);
-      });
-
       const response = await sessionStorage.del(
         aValidUser.session_token,
         aValidUser.wallet_token
       );
 
-      expect(mockSrem.mock.calls[0][0]).toBe(
-        `USERSESSIONS-${aValidUser.fiscal_code}`
-      );
-      expect(mockSrem.mock.calls[0][1]).toBe(
-        `SESSIONINFO-${aValidUser.session_token}`
-      );
       expect(mockDel).toHaveBeenCalledTimes(2);
       expect(mockDel.mock.calls[0][0]).toBe(
-        `SESSIONINFO-${aValidUser.session_token}`
-      );
-      expect(mockDel.mock.calls[0][1]).toBe(
         `SESSION-${aValidUser.session_token}`
       );
       expect(mockDel.mock.calls[1][0]).toBe(
         `WALLET-${aValidUser.wallet_token}`
       );
+      expect(mockSrem).not.toBeCalled();
 
       expect(response).toEqual(expected);
     }

--- a/src/services/__tests__/redisSessionStorage.test.ts
+++ b/src/services/__tests__/redisSessionStorage.test.ts
@@ -5,7 +5,7 @@
 /* tslint:disable:no-null-keyword */
 /* tslint:disable:no-object-mutation */
 
-import { left, Left, right } from "fp-ts/lib/Either";
+import { Either, left, Left, right } from "fp-ts/lib/Either";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import * as lolex from "lolex";
 import { createMockRedis } from "mock-redis-client";
@@ -272,6 +272,35 @@ describe("RedisSessionStorage#set", () => {
       expect(response).toEqual(expected);
     }
   );
+});
+
+describe("RedisSessionStorage#removeOtherUserSessions", () => {
+  it("should delete only older session token", async () => {
+    const oldSessionToken = "old_session_token";
+    mockSmembers.mockImplementation((_, callback) => {
+      callback(undefined, [
+        `SESSIONINFO-${oldSessionToken}`,
+        `SESSIONINFO-${oldSessionToken}2`,
+        `SESSIONINFO-${aValidUser.session_token}`
+      ]);
+    });
+    mockDel.mockImplementation((_, __, callback) => {
+      callback(undefined, 1);
+    });
+
+    const response: Either<Error, boolean> = await sessionStorage[
+      // tslint:disable-next-line: no-string-literal
+      "removeOtherUserSessions"
+    ](aValidUser);
+    expect(mockSmembers).toBeCalledTimes(1);
+    expect(mockSmembers.mock.calls[0][0]).toBe(
+      `USERSESSIONS-${aValidUser.fiscal_code}`
+    );
+    expect(mockDel).toHaveBeenCalledTimes(1);
+    expect(mockDel.mock.calls[0][0]).toBe(`SESSION-${oldSessionToken}`);
+    expect(mockDel.mock.calls[0][1]).toBe(`SESSION-${oldSessionToken}2`);
+    expect(response.isRight());
+  });
 });
 
 describe("RedisSessionStorage#getBySessionToken", () => {

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -11,7 +11,6 @@ import {
 import { FiscalCode } from "italia-ts-commons/lib/strings";
 import * as redis from "redis";
 import { isArray } from "util";
-import { FiscalCode } from "../../generated/backend/FiscalCode";
 import { SessionInfo } from "../../generated/backend/SessionInfo";
 import { SessionsList } from "../../generated/backend/SessionsList";
 import { SessionToken, WalletToken } from "../types/token";
@@ -297,7 +296,7 @@ export default class RedisSessionStorage extends RedisStorageUtils
     );
   }
 
-  private async clearExpiredSetValues(
+  public async clearExpiredSetValues(
     fiscalCode: string
   ): Promise<ReadonlyArray<Either<Error, boolean>>> {
     const userSessionSetKey = `${userSessionsSetKeyPrefix}${fiscalCode}`;

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -154,35 +154,11 @@ export default class RedisSessionStorage extends RedisStorageUtils
     if (isLeft(user)) {
       return left(user.value);
     }
-    const sessionInfoKey = `${sessionInfoKeyPrefix}${sessionToken}`;
-    const removeValueSessionInfoSet = await new Promise<Either<Error, boolean>>(
-      resolve => {
-        this.redisClient.srem(
-          `${userSessionsSetKeyPrefix}${user.value.fiscal_code}`,
-          sessionInfoKey,
-          (err, response) =>
-            resolve(
-              this.falsyResponseToError(
-                this.integerReply(err, response),
-                new Error(
-                  "Unexpected response from redis client deleting token from SessionKeySet."
-                )
-              )
-            )
-        );
-      }
-    );
-    if (isLeft(removeValueSessionInfoSet)) {
-      log.warn(
-        "Error removing session info key from session info set: %s",
-        removeValueSessionInfoSet.value.message
-      );
-    }
+
     const deleteSessionTokens = new Promise<Either<Error, true>>(resolve => {
       // Remove the specified key. A key is ignored if it does not exist.
       // @see https://redis.io/commands/del
       this.redisClient.del(
-        sessionInfoKey,
         `${sessionKeyPrefix}${sessionToken}`,
         (err, response) =>
           resolve(

--- a/src/services/redisSessionStorage.ts
+++ b/src/services/redisSessionStorage.ts
@@ -83,13 +83,13 @@ export default class RedisSessionStorage extends RedisStorageUtils
       user.fiscal_code
     );
 
-    const removeUserSessionsPromise = this.removeOtherUserSessions(user);
+    const removeOtherUserSessionsPromise = this.removeOtherUserSessions(user);
 
     const setPromisesResult = await Promise.all([
       setSessionToken,
       setWalletToken,
       saveSessionInfoPromise,
-      removeUserSessionsPromise
+      removeOtherUserSessionsPromise
     ]);
     const isSetFailed = setPromisesResult.some(isLeft);
     if (isSetFailed) {


### PR DESCRIPTION
When a new session is created for a user all the older will be removed. `SessionInfo` for all the previous sessions remain. The method `clearExpiredSetValues` now is never called, so expired sessions remain into the session history.